### PR TITLE
Implement WandbCustomCallback (cont.)

### DIFF
--- a/configs/whisper_small-librispeech_100h.yaml
+++ b/configs/whisper_small-librispeech_100h.yaml
@@ -18,3 +18,4 @@ logging_steps: 100
 save_steps: 250
 num_train_epochs: 4
 early_stopping_patience: 3
+log_preds_to_wandb: True

--- a/configs/whisper_tiny-librispeech_100h.yaml
+++ b/configs/whisper_tiny-librispeech_100h.yaml
@@ -16,5 +16,6 @@ eval_steps: 250
 generation_num_beams: 1
 logging_steps: 100
 save_steps: 250
-num_train_epochs: 4
+num_train_epochs: 5
 early_stopping_patience: 3
+log_preds_to_wandb: True

--- a/configs/whisper_tiny-librispeech_dummy.yaml
+++ b/configs/whisper_tiny-librispeech_dummy.yaml
@@ -18,3 +18,4 @@ logging_steps: 10
 save_steps: 100
 num_train_epochs: 10
 early_stopping_patience: 3
+log_preds_to_wandb: True

--- a/dataloader/dataloader.py
+++ b/dataloader/dataloader.py
@@ -1,6 +1,9 @@
 from functools import partial
+from typing import Iterable
 from datasets import DatasetDict
+
 from dataloader.dataloader_custom import load_librispeech, load_librispeech_dummy
+from utils.constants import DEFAULT_LABEL_STR_COL
 
 
 STR_TO_LOAD_FCT = {
@@ -17,3 +20,9 @@ def load_dataset_dict(dataset_name: str, **kwargs) -> DatasetDict:
     else:
         raise ValueError(f"Dataset {dataset_name} not supported")
     return dataset_dict
+
+
+def gen_from_dataset(dataset) -> Iterable[dict]:
+    """Yield the audio and reference from the dataset."""
+    for i, item in enumerate(dataset):
+        yield {**item["audio"], "reference": item[DEFAULT_LABEL_STR_COL]}

--- a/dataloader/esb.py
+++ b/dataloader/esb.py
@@ -75,7 +75,7 @@ class ESB_Datasets:
                 dataset = dataset.map(normalize_fct)
 
             # Remove any empty references:
-            dataset = dataset.filter(self.is_target_text_in_range, input_columns=[DEFAULT_LABEL_STR_COL])
+            dataset = dataset.filter(self.is_target_text_empty, input_columns=[DEFAULT_LABEL_STR_COL])
             
             # Update dataset
             self.str2dataset[dataset_name] = dataset
@@ -115,6 +115,6 @@ class ESB_Datasets:
             raise ValueError(f"Sample: {sample.keys()} has no transcript.")
 
     
-    def is_target_text_in_range(self, ref: str) -> bool:
+    def is_target_text_empty(self, ref: str) -> bool:
         ref = ref.strip()
         return ref not in self.filter_sequences

--- a/dataloader/preprocessing.py
+++ b/dataloader/preprocessing.py
@@ -41,7 +41,7 @@ def augment_dataset_fct(batch, sample_rate: int):
 
 
 def normalize_sentence(sentence: str) -> str:
-    """Normalize a sentence for transcription."""
+    """DEPRECATED. Normalize a sentence for transcription."""
     transcription = sentence
     
     if transcription.startswith('"') and transcription.endswith('"'):
@@ -57,9 +57,9 @@ def normalize_sentence(sentence: str) -> str:
     return transcription
 
 
-def prepare_dataset_fct(dataset: dict,
+def prepare_dataset_fct(dataset: DatasetDict,
                         tokenizer: WhisperTokenizer,
-                        feature_extractor: WhisperFeatureExtractor) -> dict:
+                        feature_extractor: WhisperFeatureExtractor) -> DatasetDict:
     """
     Utility to create features for a dataset.
     """    
@@ -70,18 +70,14 @@ def prepare_dataset_fct(dataset: dict,
     dataset["input_features"] = feature_extractor(
         audio["array"], sampling_rate=feature_extractor.sampling_rate).input_features[0]  # drop batch dimension
     
-    # --- Deprecated ---
-    # Normalize the transcription:
-    # sentences = normalize_sentence(dataset[DEFAULT_LABEL_STR_COL])
-    
     # Encode from target text to label ids:
-    dataset[DEFAULT_LABEL_TOKENIZED_COL] = tokenizer(dataset[DEFAULT_LABEL_STR_COL]).input_ids
+    dataset[DEFAULT_LABEL_TOKENIZED_COL] = tokenizer(dataset[DEFAULT_LABEL_STR_COL]).input_ids  # type: ignore
     
     return dataset
 
 
 def filter_empty_strings(sentence) -> bool:
-    """Filter nulls and short transcripts from dataset."""
+    """DEPRECATED. Filter nulls and short transcripts from dataset."""
     if len(sentence) < 2:
         return False
     else:
@@ -126,8 +122,5 @@ def preprocess_dataset(dataset_dict: DatasetDict,
                                   feature_extractor=feature_extractor)
         
         dataset_dict[split] = dataset_dict[split].map(prepare_dataset, num_proc=DEFAULT_NUM_PROC)
-        # --- Deprecated (we assume that the dataset is already filtered) ---
-        # dataset_dict[split] = dataset_dict[split].filter(filter_empty_strings, input_columns=[DEFAULT_LABEL_STR_COL])\
-        #                                          .map(prepare_dataset, num_proc=DEFAULT_NUM_PROC)
 
     return dataset_dict

--- a/scripts/eval_whisper_on_esb.py
+++ b/scripts/eval_whisper_on_esb.py
@@ -23,15 +23,11 @@ import evaluate
 import wandb
 
 from dataloader.esb import ESB_Datasets
-from normalization.whisper_normalization import get_whisper_normalizer
 
+from normalization.whisper_normalization import get_whisper_normalizer
+from dataloader.dataloader import gen_from_dataset
 from utils.constants import DEFAULT_LABEL_STR_COL, DEFAULT_OUTPUT_DIR, WANDB_PROJECT
 
-
-def gen_from_dataset(dataset):
-    """Yield the audio and reference from the dataset."""
-    for i, item in enumerate(dataset):
-        yield {**item["audio"], "reference": item[DEFAULT_LABEL_STR_COL]}
 
 
 def main(pretrained_model_name_or_path: str,

--- a/scripts/finetune_whisper_on_librispeech.py
+++ b/scripts/finetune_whisper_on_librispeech.py
@@ -53,9 +53,7 @@ def main(config_filepath: str):
                config=asdict(config))
     
     
-    # ----------------------   Setup   ----------------------
-    device = "cuda:0" if torch.cuda.is_available() else "cpu"
-    
+    # ----------------------   Setup   ----------------------    
     print("\n-----------------------\n")
     
     # Print environment variables:
@@ -126,7 +124,7 @@ def main(config_filepath: str):
     #       always generate the target sentence and the separator token before starting the
     #       decoding process.
     print(f"Loading pretrained model `{config.pretrained_model_name_or_path}`...")
-    model = WhisperForConditionalGeneration.from_pretrained(config.pretrained_model_name_or_path).to(device)  # type: ignore
+    model = WhisperForConditionalGeneration.from_pretrained(config.pretrained_model_name_or_path)
     model.config.forced_decoder_ids = None  # type: ignore
     model.config.suppress_tokens = []  # type: ignore
     model.config.use_cache = False  # type: ignore
@@ -171,8 +169,11 @@ def main(config_filepath: str):
     # Define callbacks:
     callbacks: List[TrainerCallback] = []
     
-    # TODO: WIP
-    # callbacks.append(WandbCustomCallback(config=config, n_batches=DEFAULT_N_SAMPLES_PER_WANDB_LOGGING_STEP))
+    if config.log_preds_to_wandb:
+        callbacks.append(WandbCustomCallback(config=config,
+                                            processor=processor,
+                                            eval_dataset=dataset_dict["test"],  # type: ignore
+                                            n_samples=DEFAULT_N_SAMPLES_PER_WANDB_LOGGING_STEP))
     
     if config.early_stopping_patience != -1:
         callbacks.append(EarlyStoppingCallback(early_stopping_patience=config.early_stopping_patience))

--- a/utils/callbacks.py
+++ b/utils/callbacks.py
@@ -1,17 +1,29 @@
-from collections import defaultdict
 from typing import Dict, Optional
-import itertools
+
+from collections import defaultdict
 
 import pandas as pd
 
-from torch.utils.data import DataLoader
+import torch
 
-from transformers import GenerationMixin, PreTrainedTokenizer, GenerationMixin
+from transformers import (GenerationMixin,
+                          GenerationMixin,
+                          WhisperProcessor,
+                          TrainingArguments,
+                          TrainerState,
+                          TrainerControl)
 from transformers.integrations import WandbCallback
+from datasets import Dataset
 import evaluate
 
+import wandb
+
+from dataloader.collator import DataCollatorSpeechSeq2SeqWithPadding
 from utils.config import Config
-from utils.constants import GEN_MAX_LENGTH, PADDING_IDX
+from utils.constants import DEFAULT_LABEL_STR_COL, GEN_MAX_LENGTH, PADDING_IDX, DEFAULT_LABEL_TOKENIZED_COL
+
+
+device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 
 
 class WandbCustomCallback(WandbCallback):
@@ -19,59 +31,105 @@ class WandbCustomCallback(WandbCallback):
     Custom Huggingface's Trainer callback to log the progress results to W&B.
     """
     
-    def __init__(self, config: Config, n_batches: int=1):
+    def __init__(self,
+                 config: Config,
+                 processor: WhisperProcessor,
+                 eval_dataset: Dataset,
+                 n_samples: int):
         super().__init__()
         self.config = config
-        self.n_batches = n_batches
+        self.processor = processor
+        
+        # Convert to iterable dataset to be able to take samples:
+        self.eval_dataset = eval_dataset
+        self.eval_dataset = self.eval_dataset.filter(lambda x: x.strip(), input_columns=[DEFAULT_LABEL_STR_COL])
+        self.eval_dataset.set_format("torch")
+        
+        self.data_collator = DataCollatorSpeechSeq2SeqWithPadding(processor=self.processor)
+        
+        self.n_samples = n_samples
         self.wer_metric = evaluate.load("wer")
     
     
     def on_log(self,
-               args,
-               state,
-               control,
+               args: TrainingArguments,
+               state: TrainerState,
+               control: TrainerControl,
                model: GenerationMixin,
-               tokenizer: PreTrainedTokenizer,
-               eval_dataloader: DataLoader,
                logs: Optional[Dict[str, float]]=None,
                **kwargs):
         
         super().on_log(args, state, control, model, logs, **kwargs)
         
-        # Slice the dataloader to get the first n batches
-        sliced_dataset = itertools.islice(eval_dataloader, self.n_batches)
-        
         records = defaultdict(list)
         
-        # Iterate through the first n samples
-        for i, data in enumerate(sliced_dataset):
-            inputs, label_ids = data
-        
+        # Iterate through the first n samples:
+        for idx, data in enumerate(self.eval_dataset):
+            if idx >= self.n_samples:
+                break
+            
+            # Log the original audio (should be done before call to DataCollator):
+            audio = wandb.Audio(data["audio"]["array"], sample_rate=data["audio"]["sampling_rate"].item())  # type: ignore
+            records["audio"].append(audio)
+            
+            # Collate the data into batches of size 1:
+            data = self.data_collator([data])  # type: ignore
+            
+            # Note that we need to move the data to the device manually (which is not the case with Trainer):
+            inputs = data["input_features"].to(device)
+            label_ids = data[DEFAULT_LABEL_TOKENIZED_COL].to(device)
+            
+            
+            # Generate the predictions:
             pred_ids = model.generate(inputs,
                                       max_length=GEN_MAX_LENGTH,
                                       num_beams=self.config.generation_num_beams)
 
             # Replace the padding index with the pad token id to undo the step we applied
-            # in the data collator to ignore padded tokens correctly in the loss:
-            label_ids[label_ids==PADDING_IDX] = tokenizer.pad_token_id
+            # in the data collator to ignore padded tokens correctly during decoding:
+            label_ids[label_ids==PADDING_IDX] = self.processor.tokenizer.pad_token_id  # type: ignore
+            
             
             # Decode the predictions:
-            batch_pred_str = tokenizer.batch_decode(pred_ids, skip_special_tokens=True, normalize=True)
+            curr_pred_str_raw = self.processor.tokenizer.batch_decode(pred_ids, skip_special_tokens=False, normalize=True)[0]  # type: ignore
+            curr_pred_str_raw = "".join(curr_pred_str_raw)
+            
+            curr_pred_str = self.processor.tokenizer.batch_decode(pred_ids, skip_special_tokens=True, normalize=True)[0]  # type: ignore
+            curr_pred_str = "".join(curr_pred_str)
+            
+            records["pred_str_raw"].append(curr_pred_str_raw)
+            records["pred_str"].append(curr_pred_str)
+            
             
             # Decode the labels:
-            batch_label_str_raw = tokenizer.batch_decode(label_ids, skip_special_tokens=False, normalize=False)
-            batch_label_str = tokenizer.batch_decode(label_ids, skip_special_tokens=True, normalize=True)
-
-            for pred_str, label_str_raw, label_str in zip(batch_pred_str, batch_label_str_raw, batch_label_str):
-                records["pred_str"].append(pred_str)
-                records["label_str_raw"].append(label_str_raw)
-                records["label_str"].append(label_str)
-                
-                # Compute the WER in percent per example:
-                records["wer"].append(100 * self.wer_metric.compute(references=label_str, predictions=pred_str))  # type: ignore
+            curr_label_str_raw = self.processor.tokenizer.batch_decode(label_ids, skip_special_tokens=False, normalize=False)[0]  # type: ignore
+            curr_label_str_raw = "".join(curr_label_str_raw)
+            
+            curr_label_str = self.processor.tokenizer.batch_decode(label_ids, skip_special_tokens=True, normalize=True)[0]  # type: ignore
+            curr_label_str = "".join(curr_label_str)
+            
+            records["label_str_raw"].append(curr_label_str_raw)
+            records["label_str"].append(curr_label_str)
+            
+            
+            # Compute the WER:
+            records["wer"].append(100 * self.wer_metric.compute(references=[curr_label_str], predictions=[curr_pred_str]))  # type: ignore
+            
+            # Add boolean flag to indicate whether the prediction is correct:
+            records["is_correct"].append(curr_label_str == curr_pred_str)
+            
+            # Add information about the current training state:
+            records["epoch"].append(state.epoch)
+            records["step"].append(state.global_step)
+        
+        
+        # Create a dataframe from the records:
+        df = pd.DataFrame(records)
+        df["wer"] = df["wer"].round(2)
+        
         
         # Create a new wandb table:
-        table = self._wandb.Table(dataframe=pd.DataFrame(records))
-        self._wandb.log({"sample_predictions": table})
+        table_preds = self._wandb.Table(dataframe=df)
+        self._wandb.log({"sample_predictions": table_preds})
         
         return

--- a/utils/config.py
+++ b/utils/config.py
@@ -28,6 +28,7 @@ class Config:
     logging_steps: int
     num_train_epochs: int
     early_stopping_patience: int
+    log_preds_to_wandb: bool = True
 
 
 def load_yaml_config(config_file: str) -> Config:

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -6,7 +6,7 @@ DEFAULT_ENV_CONFIG_FILEPATH = "configs/env_config.yaml"
 
 # ------ wandb ------
 WANDB_PROJECT = "distilling-and-forgetting-in-large-pre-trained-models"
-DEFAULT_N_SAMPLES_PER_WANDB_LOGGING_STEP = 16
+DEFAULT_N_SAMPLES_PER_WANDB_LOGGING_STEP = 8
 
 
 # ------ Constants ------


### PR DESCRIPTION
## Implement WandbCustomCallback (cont.)
- Follow-up of https://github.com/tonywu71/distilling-and-forgetting-in-large-pre-trained-models/pull/3
- Various fixes in `callbacks.py`
- Refacto `gen_from_dataset` into `dataloader`
- Rename method in `ESB_Datasets`
- Remove deprecated calls in `preprocessing`
- Remove redundant `model.to(device)`
- Add support for `WandbCustomCallback` in the fine-tuning script
- Add `log_preds_to_wandb` arg to `Config`